### PR TITLE
tei2txt.xsl: use for-each instead of recursive template

### DIFF
--- a/tei2txt/share/xslt/tei2txt.xsl
+++ b/tei2txt/share/xslt/tei2txt.xsl
@@ -458,13 +458,13 @@
         <xsl:when test="@extent">
             <xsl:call-template name="output_gap">
                 <xsl:with-param name="output" select="$gap_char" />
-                <xsl:with-param name="recLevel" select="@extent"/>
+                <xsl:with-param name="amount" select="@extent"/>
             </xsl:call-template>
         </xsl:when>
         <xsl:when test="@quantity">
             <xsl:call-template name="output_gap">
                 <xsl:with-param name="output" select="$gap_char" />
-                <xsl:with-param name="recLevel" select="@quantity"/>
+                <xsl:with-param name="amount" select="@quantity"/>
             </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
@@ -475,14 +475,12 @@
 </xsl:template>
 <xsl:template name="output_gap">
     <xsl:param name="output" />
-    <xsl:param name="recLevel" />
-    <xsl:value-of select="$output"/>
-    <xsl:if test="$recLevel > 1">
-        <xsl:call-template name="output_gap">
-            <xsl:with-param name="output" select="$output" />
-            <xsl:with-param name="recLevel" select="$recLevel - 1" />
-        </xsl:call-template>
-    </xsl:if>
+    <xsl:param name="amount" />
+    <!-- rekursive Anwendung problematisch wegen xsltMaxDepth -->
+    <!-- Annahme: genügend sonstige XML-Elemente zum Zählen -->
+    <xsl:for-each select="//*[position() &lt;= $amount]">
+      <xsl:value-of select="$output"/>
+    </xsl:for-each>
 </xsl:template>
 
 <!--=====================================-->


### PR DESCRIPTION
Here's another one:

```
runtime error: file /usr/local/share/perl/5.26.1/auto/share/dist/DTA-TEI-Text/xslt/tei2txt.xsl line 479 element value-of
xsltApplySequenceConstructor: A potential infinite template recursion was detected.
You can adjust xsltMaxDepth (--maxdepth) in order to raise the maximum number of nested template calls and variables/params (currently set to 250).
Templates:
#0 name output_gap 
#1 name output_gap 
#2 name output_gap 
#3 name output_gap 
#4 name output_gap 
#5 name output_gap 
#6 name output_gap 
#7 name output_gap 
#8 name output_gap 
#9 name output_gap 
#10 name output_gap 
#11 name output_gap 
#12 name output_gap 
#13 name output_gap 
#14 name output_gap 
Variables:
#0
recLevel 
output 
#1
output 
#2
recLevel 
output 
#3
output 
#4
recLevel 
output 
#5
output 
#6
recLevel 
output 
#7
output 
#8
recLevel 
output 
#9
output 
#10
recLevel 
output 
#11
output 
#12
recLevel 
output 
#13
output 
#14
recLevel 
output 
 at /usr/local/share/perl/5.26.1/DTA/TEI/Text/Transform.pm line 205.
```

So clearly, although none of our `@quantity` values surpasses the mentioned limit of `xsltMaxDepth=250`, we get an ugly warning here.

This happens with libxml2==2.9.4.

I found no proper replacement in XSLT 1.1 for the repeated gap_char output, but this hack serves its purpose.